### PR TITLE
Make SMSC an optional field for encoding and decoding SMS PDU

### DIFF
--- a/c_src/esms.cpp
+++ b/c_src/esms.cpp
@@ -191,7 +191,7 @@ static ERL_NIF_TERM encode_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
     goto EERR;
   }
   //default values
-  pdu.setSMSC("123");
+  // pdu.setSMSC("123");
   pdu.setNumber("123");
   pdu.setAlphabet (PDU::UCS2);
 

--- a/c_src/pdu.cpp
+++ b/c_src/pdu.cpp
@@ -742,8 +742,8 @@ bool PDU::parse()
         return false;
     }
     
-    if (!parseSMSC())
-        return false;
+    // if (!parseSMSC())
+    //    return false;
     
     if (strlen(m_pdu_ptr) < 2)
     {
@@ -1456,7 +1456,7 @@ void PDU::generate()
             sprintf(m_pdu, "%02X%s%s", (int)strlen(tmp_smsc) / 2 + 1, 
                     (tmp_smsc[1] == '0') ? "81": "91", tmp_smsc);
         else
-            strcpy(m_pdu, "00");
+            strcpy(m_pdu, "\0");
         
         smsc_len = strlen(m_pdu);
         


### PR DESCRIPTION
Changed it to make SMSC optional to generate TPDU